### PR TITLE
Workshop Lookup Fac & CM as AF Man Bug

### DIFF
--- a/src/app/workshops/workshop-form/workshop-form.component.ts
+++ b/src/app/workshops/workshop-form/workshop-form.component.ts
@@ -176,7 +176,7 @@ export class WorkshopFormComponent implements OnInit {
   }
 
   public getAffiliate(): string {
-    if (this.workshopForm.value.affiliate.sfId) return this.workshopForm.value.affiliate.sfId;
+    if (this.workshopForm.value.affiliate.sfObject) return this.workshopForm.value.affiliate.sfObject.sfId;
     else return this.auth.user.affiliate;
   }
 


### PR DESCRIPTION
### Cause: Line 179
The `SFLookupComponent` stores the lookup object in a member variable called `sfObject`. When you access the component via the value field on the form you must go through the `sfObject`.

### Fix
Changed the logic to check for definition of the `sfObject` member on the affiliate lookup, instead of `sfId` on the affiliate lookup.